### PR TITLE
[FEATURE] Add Content-Type header when file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ routes:
         - methods: [any]
           route: '/schema.json'
           file: 'EXT:myextension/Resources/Private/Api/schema_v1.json'
+          contentType: 'application/json'
         - methods: [get]
           route: '/article'
           callback: B13\MyExtension\Controller\LoadArticlesController

--- a/src/Middleware/SlimInitiator.php
+++ b/src/Middleware/SlimInitiator.php
@@ -103,7 +103,7 @@ class SlimInitiator implements MiddlewareInterface
             if ($details['file']) {
                 $route = $collector->get($details['route'], function(ServerRequestInterface $request, ResponseInterface $response) use ($details) {
                     $filename = GeneralUtility::getFileAbsFileName($details['file']);
-                    if ($details['contentType']) {
+                    if (isset($details['contentType'])) {
                         $response = $response->withHeader('Content-Type', $details['contentType']);
                     }
                     $response->getBody()->write(file_get_contents($filename));

--- a/src/Middleware/SlimInitiator.php
+++ b/src/Middleware/SlimInitiator.php
@@ -103,6 +103,9 @@ class SlimInitiator implements MiddlewareInterface
             if ($details['file']) {
                 $route = $collector->get($details['route'], function(ServerRequestInterface $request, ResponseInterface $response) use ($details) {
                     $filename = GeneralUtility::getFileAbsFileName($details['file']);
+                    if ($details['contentType']) {
+                        $response = $response->withHeader('Content-Type', $details['contentType']);
+                    }
                     $response->getBody()->write(file_get_contents($filename));
                     return $response;
                 });


### PR DESCRIPTION
Outputting just a file which is not HTML there is now an option to set the Content-Type to e.g. application/json.