### PR TITLE
[BUGFIX] Too few arguments passed

### DIFF
--- a/src/Middleware/ExtbaseBridge.php
+++ b/src/Middleware/ExtbaseBridge.php
@@ -50,7 +50,7 @@ class ExtbaseBridge implements MiddlewareInterface
         }
 
         $request = $this->bootFrontend($request);
-        $this->bootExtbase();
+        $this->bootExtbase($request);
 
         return $handler->handle($request);
     }
@@ -105,12 +105,12 @@ class ExtbaseBridge implements MiddlewareInterface
         return $request;
     }
 
-    protected function bootExtbase(): void
+    protected function bootExtbase(ServerRequestInterface $request): void
     {
         GeneralUtility::makeInstance(Bootstrap::class)->initialize([
             'extensionName' => 'slimphp',
             'vendorName' => 'B13',
             'pluginName' => 'slimphp',
-        ]);
+        ], $request);
     }
 }


### PR DESCRIPTION
 Core: Exception handler (WEB): Uncaught TYPO3 Exception: Too few arguments to function TYPO3\CMS\Extbase\Core\Bootstrap::initialize(), 1 passed in /vendor/b13/slimphp-bridge/src/Middleware/ExtbaseBridge.php on line 110 and exactly 2 expected | ArgumentCountError thrown in file /vendor/typo3/cms-extbase/Classes/Core/Bootstrap.php in line 89.

TYPO3 CMS 12.4.0 with PHP 8.2.0