### PR TITLE
[BUGFIX] Apply 2nd argument in v12.4+ only

### DIFF
--- a/src/Middleware/ExtbaseBridge.php
+++ b/src/Middleware/ExtbaseBridge.php
@@ -107,10 +107,18 @@ class ExtbaseBridge implements MiddlewareInterface
 
     protected function bootExtbase(ServerRequestInterface $request): void
     {
-        GeneralUtility::makeInstance(Bootstrap::class)->initialize([
-            'extensionName' => 'slimphp',
-            'vendorName' => 'B13',
-            'pluginName' => 'slimphp',
-        ], $request);
+        if (version_compare($this->typo3Version, '12.4', '>=')) {
+            GeneralUtility::makeInstance(Bootstrap::class)->initialize([
+               'extensionName' => 'slimphp',
+               'vendorName' => 'B13',
+               'pluginName' => 'slimphp',
+           ], $request);
+        }else {
+            GeneralUtility::makeInstance(Bootstrap::class)->initialize([
+               'extensionName' => 'slimphp',
+               'vendorName' => 'B13',
+               'pluginName' => 'slimphp',
+           ]);
+        }
     }
 }


### PR DESCRIPTION
The parameter was added with https://github.com/TYPO3/typo3/commit/b193d256ae1b71cebb3a8ea1dc0de75015e634e4 and published to TYPO3 CMS 12.4.0, so prior versions have no 2nd parameter in \TYPO3\CMS\Extbase\Core\Bootstrap::initialize method.