### PR TITLE
[BUGFIX] Do not boot Slim if route prefix not exactly matched

### DIFF
--- a/src/Middleware/SlimInitiator.php
+++ b/src/Middleware/SlimInitiator.php
@@ -63,7 +63,7 @@ class SlimInitiator implements MiddlewareInterface
             }
 
             $prefix = $config['route'] ?? '/';
-            if (strpos($request->getUri()->getPath(), $prefix) !== 0) {
+            if (strpos($request->getUri()->getPath(), rtrim($prefix, '/') . '/') !== 0) {
                 continue;
             }
 


### PR DESCRIPTION
If the route prefix is `/api`, Slim must not boot for an url like `/api-external`.

In order to fix that, the route prefix is now matched like `/api/`.

The only downside is that `/api` (without trailing slash) is not handled by Slim anymore.