### PR TITLE
[BUGFIX] remove superfluous return in front of throw

### DIFF
--- a/src/Middleware/SlimInitiator.php
+++ b/src/Middleware/SlimInitiator.php
@@ -99,7 +99,7 @@ class SlimInitiator implements MiddlewareInterface
                     case 403:
                         return $errorController->accessDeniedAction($request, $e->getMessage());
                     default:
-                        return throw $e;
+                        throw $e;
                 }
             }
         }


### PR DESCRIPTION
Running into a ParseError w/ TYPO3 10.4.37 (sadly, upgrade planned) and PHP 7.4.33:
```syntax error, unexpected 'throw' (T_THROW), expecting ';'```