### PR TITLE
TYPO3 v13 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,9 @@
 		"issues": "https://github.com/b13/slimphp/issues"
 	},
 	"require": {
-		"typo3/cms-core": "^10.4 || ^11.5 || ^12.4",
-		"typo3/cms-frontend": "^10.4 || ^11.5 || ^12.4",
-		"slim/slim": "^4.1",
-		"sapphirecat/slim4-http-interop-adapter": "^1.0"
+		"typo3/cms-core": "^12.4 || ^13.4",
+		"typo3/cms-frontend": "^12.4 || ^13.4",
+		"slim/slim": "^4.14"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.5",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '0.6.2',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-12.9.99',
+            'typo3' => '12.4.0-13.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/src/Middleware/ExtbaseBridge.php
+++ b/src/Middleware/ExtbaseBridge.php
@@ -10,7 +10,6 @@ namespace B13\SlimPhp\Middleware;
  * the terms of the GNU General Public License, either version 2
  * of the License, or any later version.
  */
-
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -27,13 +26,11 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class ExtbaseBridge implements MiddlewareInterface
 {
-    private string $typo3Version = '';
     private Context $context;
 
     public function __construct(Context $context)
     {
         $this->context = $context;
-        $this->typo3Version = (string)(new \TYPO3\CMS\Core\Information\Typo3Version());
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/src/Middleware/ExtbaseBridge.php
+++ b/src/Middleware/ExtbaseBridge.php
@@ -49,7 +49,6 @@ class ExtbaseBridge implements MiddlewareInterface
             $GLOBALS['TSFE']->id = $site->getRootPageId();
         }
 
-        $request = $this->bootFrontend($request);
         $this->bootExtbase($request);
 
         return $handler->handle($request);
@@ -57,68 +56,31 @@ class ExtbaseBridge implements MiddlewareInterface
 
     protected function createGlobalTsfe(Site $site, ServerRequestInterface $request): ServerRequestInterface
     {
-        if (version_compare($this->typo3Version, '11.5', '>=')) {
-            $controller = GeneralUtility::makeInstance(
-                TypoScriptFrontendController::class,
-                $this->context,
-                $site,
-                $request->getAttribute('language', $site->getDefaultLanguage()),
-                new PageArguments($site->getRootPageId(), '0', []),
-                $request->getAttribute('frontend.user')
-            );
+        $controller = GeneralUtility::makeInstance(
+            TypoScriptFrontendController::class,
+            $this->context,
+            $site,
+            $request->getAttribute('language', $site->getDefaultLanguage()),
+            new PageArguments($site->getRootPageId(), '0', []),
+            $request->getAttribute('frontend.user')
+        );
 
-            $controller->determineId($request);
+        $request = $request->withAttribute('frontend.controller', $controller);
 
-            $request = $request->withAttribute('frontend.controller', $controller);
+        // Make TSFE globally available
+        // @todo deprecate $GLOBALS['TSFE'] once TSFE is retrieved from the
+        //       PSR-7 request attribute frontend.controller throughout TYPO3 core
+        $GLOBALS['TSFE'] = $controller;
 
-            // Make TSFE globally available
-            // @todo deprecate $GLOBALS['TSFE'] once TSFE is retrieved from the
-            //       PSR-7 request attribute frontend.controller throughout TYPO3 core
-            $GLOBALS['TSFE'] = $controller;
-        } else {
-            $GLOBALS['TSFE'] = GeneralUtility::makeInstance(
-                TypoScriptFrontendController::class,
-                null,
-                $site,
-                $request->getAttribute('language'),
-                null,
-                $request->getAttribute('frontend.user')
-            );
-        }
-
-        return $request;
-    }
-
-    protected function bootFrontend(ServerRequestInterface $request): ServerRequestInterface
-    {
-        if (version_compare($this->typo3Version, '12.2', '>=')) {
-            // Run Frontend TypoScript
-            $request = $GLOBALS['TSFE']->getFromCache($request);
-        } elseif (version_compare($this->typo3Version, '11.5', '>=')) {
-            // nothing to do, TSFE is already ready
-        } else {
-            $GLOBALS['TSFE']->fetch_the_id($request);
-            $GLOBALS['TSFE']->getConfigArray($request);
-            $GLOBALS['TSFE']->settingLanguage($request);
-            $GLOBALS['TSFE']->newCObj();
-        }
         return $request;
     }
 
     protected function bootExtbase(ServerRequestInterface $request): void
     {
-        if (version_compare($this->typo3Version, '12.4', '>=')) {
-            GeneralUtility::makeInstance(Bootstrap::class)->initialize([
-               'extensionName' => 'slimphp',
-               'vendorName' => 'B13',
-               'pluginName' => 'slimphp',
-           ], $request);
-        }else {
-            GeneralUtility::makeInstance(Bootstrap::class)->initialize([
-               'extensionName' => 'slimphp',
-               'vendorName' => 'B13',
-               'pluginName' => 'slimphp',
-           ]);
-        }
+        GeneralUtility::makeInstance(Bootstrap::class)->initialize([
+            'extensionName' => 'slimphp',
+            'vendorName' => 'B13',
+            'pluginName' => 'slimphp',
+        ], $request);
     }
 }

--- a/src/Service/RequestedLanguageToSiteLanguageResolverService.php
+++ b/src/Service/RequestedLanguageToSiteLanguageResolverService.php
@@ -34,7 +34,7 @@ class RequestedLanguageToSiteLanguageResolverService
             /** @var SiteLanguage $language */
             foreach ($site->getLanguages() as $language) {
                 [$locale] = explode('.', strtolower((string)$language->getLocale()));
-                if ($requestLanguageCode === $locale || $requestLanguageCode === $language->getTwoLetterIsoCode()) {
+                if ($requestLanguageCode === $locale || $requestLanguageCode === $language->getLocale()->getLanguageCode()) {
                     return $language;
                 }
             }


### PR DESCRIPTION
## **Overview**
This PR updates the extension to support TYPO3 v12 and v13, following discussions at TYPO3 Developer Days 2025.

## **Changes Made**
### **TYPO3 Compatibility**:
- Removed all TYPO3 version condition checks (obsolete in v12/v13)
- Dropped TYPO3 v11 support due to complex compatibility issues with v13
- Resolved deprecation warnings and missing function calls
- Updated extension configuration for new TYPO3 versions

### **Framework Updates:**
- Bumped Slim Framework to v4 (latest release)
- Added full PHP 8.x version support
- Updated dependencies to match new requirements

## **Breaking Changes**
- TYPO3 v11 no longer supported - users must upgrade to v12+ first
- Minimum PHP version requirements updated

## **Known Issues**
- ExtbaseBridge needs additional work for TYPO3 v14 support due to TyposcriptFrontendController major changes

## **Testing**
- Tested with TYPO3 v12.4 LTS
- Tested with TYPO3 v13.x
- All existing functionality verified

## **Next Steps**
- Plan ExtbaseBridge refactoring for TYPO3 v14 compatibility
- Monitor for additional deprecations in future TYPO3 releases